### PR TITLE
fix: product name should be the same with package name for deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Botj
 
-J is a bot that helps you to automate your tasks. It is a desktop application built with Electron tested on Windows 10/11 and macOS.
+J is a bot that helps you to automate your tasks. It is a desktop application built with Electron tested on Windows 10/11, macOS and Ubuntu.
 
 ## Development
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -15,14 +15,11 @@ const config: ForgeConfig = {
   packagerConfig: {
     icon: "./src/assets/images/app_icon",
     asar: true,
-    name: "j",
-    executableName: "j",
   },
   rebuildConfig: {},
   makers: [
     new MakerSquirrel({}),
-    new MakerZIP({}, ["darwin"]),
-    new MakerRpm({}),
+    new MakerZIP({}, ["darwin", "linux"]),
     new MakerDeb({}),
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botj",
-  "productName": "J",
+  "productName": "botj",
   "version": "1.0.0",
   "description": "J is a bot.",
   "main": ".webpack/main",


### PR DESCRIPTION
Fix ubuntu packaging deb problem.